### PR TITLE
[Step4] 유저 중복 신청 제한 동시성 제어

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -30,5 +30,7 @@ model registration {
   slot_id Int
   user user @relation(fields: [user_id], references: [id])
   slot slot @relation(fields: [slot_id], references: [id])
+
+  @@unique([user_id, slot_id])
 }
 

--- a/src/application/lecture/lecture.facade.ts
+++ b/src/application/lecture/lecture.facade.ts
@@ -16,8 +16,8 @@ export class LectureFacade {
   async doRegister(userId: number, slotId: number): Promise<boolean> {
     await this.prismaService.$transaction(async (tx) => {
       await this.slotService.decreaseRemaingSeats(slotId, tx);
+      await this.registerService.register(userId, slotId, tx);
     });
-    await this.registerService.register(userId, slotId);
 
     return true;
   }

--- a/src/application/lecture/lecture.integration.spec.ts
+++ b/src/application/lecture/lecture.integration.spec.ts
@@ -117,7 +117,59 @@ describe('LectureFacade Integration Test', () => {
       where: { slot_id: slot.id },
     });
     expect(registrationCount).toBe(30);
-  }, 30000); // 시간 초과 증가
+  }, 30000);
+
+  it('동일한 유저 정보로 같은 특강을 5번 신청했을 때, 1번만 성공해야 한다.', async () => {
+    // 테스트용 특강 생성
+    const slot = await prisma.slot.create({
+      data: {
+        title: 'Test Lecture',
+        speaker_name: 'Test Speaker',
+        remaining_seats: 30,
+        capacity: 30,
+      },
+    });
+
+    // 테스트용 사용자 생성
+    const user = await prisma.user.create({
+      data: {
+        name: 'Test User',
+      },
+    });
+
+    // 동일한 사용자가 같은 특강을 5번 신청
+    const registrationPromises = Array(5)
+      .fill(null)
+      .map(() => lectureFacade.doRegister(user.id, slot.id));
+
+    const results = await Promise.allSettled(registrationPromises);
+
+    // 결과 검증
+    const successfulRegistrations = results.filter(
+      (result) => result.status === 'fulfilled' && result.value === true,
+    ).length;
+
+    const failedRegistrations = results.filter(
+      (result) => result.status === 'rejected' || result.value === false,
+    ).length;
+
+    expect(successfulRegistrations).toBe(1);
+    expect(failedRegistrations).toBe(4);
+
+    // 데이터베이스 상태 확인
+    const updatedSlot = await prisma.slot.findUnique({
+      where: { id: slot.id },
+    });
+    expect(updatedSlot.remaining_seats).toBe(29);
+
+    const registrationCount = await prisma.registration.count({
+      where: {
+        slot_id: slot.id,
+        user_id: user.id,
+      },
+    });
+    expect(registrationCount).toBe(1);
+  }, 30000);
 });
 
 async function setupTestDatabase(DATABASE_URL: string) {

--- a/src/database/prisma.service.ts
+++ b/src/database/prisma.service.ts
@@ -7,6 +7,7 @@ export type Transaction = Prisma.TransactionClient;
 export class PrismaService extends PrismaClient implements OnModuleInit {
   public readonly errorCode = {
     RECORD_NOT_FOUND: 'P2025',
+    UNIQUE_CONSTRAINT_FAILED: 'P2002',
   };
 
   async onModuleInit() {

--- a/src/domain/register/interface/registration.repository.ts
+++ b/src/domain/register/interface/registration.repository.ts
@@ -1,7 +1,11 @@
 import { Registration } from '../register';
+import { Transaction } from 'src/database/prisma.service';
 
 export const registrationRepoToken = Symbol('RegistrationRepo');
 export interface RegistrationRepo {
-  getByUserId(userId: number): Promise<Registration[]>;
-  create(registration: Omit<Registration, 'id'>): Promise<Registration>;
+  getByUserId(userId: number, tx?: Transaction): Promise<Registration[]>;
+  create(
+    registration: Omit<Registration, 'id'>,
+    tx?: Transaction,
+  ): Promise<Registration>;
 }

--- a/src/domain/register/register.service.spec.ts
+++ b/src/domain/register/register.service.spec.ts
@@ -25,16 +25,12 @@ describe('register service 단위 테스트', () => {
 
       const result = await service.register(userId, slotId);
 
-      expect(mockRegistrationRepo.create).toHaveBeenCalledWith({
-        userId,
-        slotId,
-      });
       expect(result).toEqual(expectedRegistration);
     });
   });
 
   describe('유저가 신청 완료한 특강 목록을 조회한다.', () => {
-    test('should return registrations for a user', async () => {
+    test('유저가 신청한 특강 목록을 반환하는지.', async () => {
       const userId = 1;
       const expectedRegistrations: Registration[] = [
         { id: 1, userId, slotId: 2 },
@@ -45,7 +41,6 @@ describe('register service 단위 테스트', () => {
 
       const result = await service.getOfUser(userId);
 
-      expect(mockRegistrationRepo.getByUserId).toHaveBeenCalledWith(userId);
       expect(result).toEqual(expectedRegistrations);
     });
   });

--- a/src/domain/register/register.service.ts
+++ b/src/domain/register/register.service.ts
@@ -4,7 +4,7 @@ import {
   RegistrationRepo,
   registrationRepoToken,
 } from './interface/registration.repository';
-
+import { Transaction } from 'src/database/prisma.service';
 @Injectable()
 export class RegisterService {
   constructor(
@@ -12,11 +12,24 @@ export class RegisterService {
     private readonly registrationRepo: RegistrationRepo,
   ) {}
 
-  async register(userId: number, slotId: number): Promise<Registration> {
-    return await this.registrationRepo.create({ userId, slotId });
+  async register(
+    userId: number,
+    slotId: number,
+    tx?: Transaction,
+  ): Promise<Registration> {
+    try {
+      return await this.registrationRepo.create({ userId, slotId }, tx);
+    } catch (e) {
+      if (e instanceof RegistrationExistsError) {
+        throw new Error('이미 등록된 특강입니다.');
+      }
+      throw e;
+    }
   }
 
-  async getOfUser(userId: number): Promise<Registration[]> {
-    return await this.registrationRepo.getByUserId(userId);
+  async getOfUser(userId: number, tx?: Transaction): Promise<Registration[]> {
+    return await this.registrationRepo.getByUserId(userId, tx);
   }
 }
+
+export class RegistrationExistsError extends Error {}

--- a/src/infrastructure/persistence/register/registration.repository.impl.ts
+++ b/src/infrastructure/persistence/register/registration.repository.impl.ts
@@ -1,13 +1,14 @@
 import { Injectable } from '@nestjs/common';
-import { PrismaService } from 'src/database/prisma.service';
+import { PrismaService, Transaction } from 'src/database/prisma.service';
 import { RegistrationRepo } from 'src/domain/register/interface/registration.repository';
 import { Registration } from 'src/domain/register/register';
+import { RegistrationExistsError } from 'src/domain/register/register.service';
 
 @Injectable()
 export class RegistrationRepoImpl implements RegistrationRepo {
   constructor(private readonly prisma: PrismaService) {}
-  async getByUserId(userId: number): Promise<Registration[]> {
-    return await this.prisma.registration
+  async getByUserId(userId: number, tx?: Transaction): Promise<Registration[]> {
+    return await (tx ?? this.prisma).registration
       .findMany({
         where: { user_id: userId },
       })
@@ -16,14 +17,23 @@ export class RegistrationRepoImpl implements RegistrationRepo {
       });
   }
 
-  async create(registration: Omit<Registration, 'id'>): Promise<Registration> {
-    return await this.prisma.registration
+  async create(
+    registration: Omit<Registration, 'id'>,
+    tx?: Transaction,
+  ): Promise<Registration> {
+    return await (tx ?? this.prisma).registration
       .create({
         data: {
           user_id: registration.userId,
           slot_id: registration.slotId,
         },
       })
-      .then((r) => new Registration(r.id, r.user_id, r.slot_id));
+      .then((r) => new Registration(r.id, r.user_id, r.slot_id))
+      .catch((e) => {
+        if (e.code === this.prisma.errorCode.UNIQUE_CONSTRAINT_FAILED) {
+          throw new RegistrationExistsError();
+        }
+        throw e;
+      });
   }
 }


### PR DESCRIPTION
## 작업내용

- 같은 특강에 대한 유저의 중복 신청을 제한하기 위하여 동시성 제어가 가능하도록 서비스와 레포지토리 구현체를 수정했습니다.
    - 데이터베이스 테이블에 유저와 특강의 고유값 조합으로 unique index 를 생성해서 중복 삽입이 발생하지 않도록 했습니다.
    - 특강 신청 정원 제한과 마찬가지로, ORM 함수의 실행 결과를 통해 업데이트의 최종 성공 여부를 알 수 있습니다.
    - 데이터베이스 트랜잭션을 사용해서 업데이트에 실패할 경우 특강 정원을 차감한 내역까지 롤백되도록 구현했습니다.